### PR TITLE
Make `Button` plain, add `CheckButton`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,18 +135,22 @@ impl<T> Menu<T> {
         Self {
             items: Vec::new(),
         }
-    }    
-    
+    }
+
 }
 
 /// Various menu items that can be added to a [Menu]
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum MenuItem<T> {
     Separator,
-    Button {
+    CheckButton {
         name: String,
         signal: T,
         checked: bool
+    },
+    Button {
+        name: String,
+        signal: T,
     },
     Menu {
         name: String,
@@ -168,7 +172,6 @@ impl<T> MenuItem<T> {
         Self::Button {
             name: name.to_string(),
             signal,
-            checked: false,
         }
     }
 
@@ -176,7 +179,7 @@ impl<T> MenuItem<T> {
     pub fn check_button<S>(name: S, signal: T, checked: bool) -> Self
         where S: ToString
     {
-        Self::Button {
+        Self::CheckButton {
             name: name.to_string(),
             signal,
             checked,

--- a/src/platform/linux/menu.rs
+++ b/src/platform/linux/menu.rs
@@ -42,7 +42,7 @@ impl<T> DBusMenu<T> {
         }
     }
 
-} 
+}
 
 impl<T: Clone + Send + 'static> DBusMenu<T> {
     pub async fn update_menu(&self, menu: Menu<T>, signal_context: &SignalContext<'_>) -> zbus::Result<()> {
@@ -86,12 +86,21 @@ fn build_menu<T>(menu: Menu<T>) -> Vec<MenuEntry<T>> {
                 children: vec![],
                 signal: None,
             },
-            MenuItem::Button { name, signal, checked } => MenuEntry {
-                properties: HashMap::from([
-                    (String::from("label"), OwnedValue::from(Str::from(name))),
-                    (String::from("toggle-type"), OwnedValue::from(Str::from_static("checkmark"))),
-                    (String::from("toggle-state"), OwnedValue::from(if checked {1i32 } else { 0i32 }))
-                ]),
+            MenuItem::CheckButton { name, signal, checked } => MenuEntry {
+                properties:
+                    HashMap::from([
+                        (String::from("label"), OwnedValue::from(Str::from(name))),
+                        (String::from("toggle-type"), OwnedValue::from(Str::from_static("checkmark"))),
+                        (String::from("toggle-state"), OwnedValue::from(if checked {1i32 } else { 0i32 }))
+                    ]),
+                children: vec![],
+                signal: Some(signal),
+            },
+            MenuItem::Button { name, signal } => MenuEntry {
+                properties:
+                    HashMap::from([
+                        (String::from("label"), OwnedValue::from(Str::from(name))),
+                    ]),
                 children: vec![],
                 signal: Some(signal),
             },


### PR DESCRIPTION
Renames previous `MenuItem::Button` to `MenuItem::CheckButton` and adds a plain `MenuItem::Button` item which still emits a signal but has only a label.