### PR TITLE
Fix empty menu and tray icon disappearance on Waybar

### DIFF
--- a/src/platform/linux/menu.rs
+++ b/src/platform/linux/menu.rs
@@ -187,7 +187,7 @@ fn collect<T>(ids: &[usize], entries: &[MenuEntry<T>], property_names: &[&str], 
             .map(|id| {
                 let entry = entries.get(id).unwrap();
                 Value::new((
-                    id as u32,
+                    id as i32,
                     entry.get_properties(property_names),
                     collect(&entry.children, entries, property_names, depth - 1)
                 ))

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -125,9 +125,8 @@ impl<T: Clone + Send + 'static> NativeTrayIcon<T> {
             conn.executor().spawn(
                 async move {
                     proxy.inner().receive_owner_changed().await?.then(|new_owner| {
-                        // TODO Hack?
-                        let proxy = proxy.clone();
-                        let name = name.clone();
+                        let proxy = &proxy;
+                        let name = &name;
                         async move {
                             match new_owner {
                                 Some(_) => proxy.register_status_notifier_item(&name).await,


### PR DESCRIPTION
* In the `collect()` function for `com.canonical.dbusmenu`, convert `id` to `i32` instead of `u32`, as Waybar expects a signed integer:
  ```
  (waybar:20505): GLib-CRITICAL **: 12:58:10.362: g_variant_get_int32: assertion 'g_variant_is_of_type (value, G_VARIANT_TYPE_INT32)' failed
  
  (waybar:20505): LIBDBUSMENU-GLIB-WARNING **: 12:58:10.362: Asking for properties from same ID twice: 0
  
  (waybar:20505): GLib-CRITICAL **: 12:58:10.362: g_variant_get_int32: assertion 'g_variant_is_of_type (value, G_VARIANT_TYPE_INT32)' failed
  
  (waybar:20505): LIBDBUSMENU-GLIB-WARNING **: 12:58:10.362: Asking for properties from same ID twice: 0
  
  (waybar:20505): GLib-CRITICAL **: 12:58:10.362: g_variant_get_int32: assertion 'g_variant_is_of_type (value, G_VARIANT_TYPE_INT32)' failed
  
  (waybar:20505): LIBDBUSMENU-GLIB-WARNING **: 12:58:10.362: Asking for properties from same ID twice: 0
  
  (waybar:20505): GLib-CRITICAL **: 12:58:10.362: g_variant_get_int32: assertion 'g_variant_is_of_type (value, G_VARIANT_TYPE_INT32)' failed
  
  (waybar:20505): LIBDBUSMENU-GLIB-WARNING **: 12:58:10.362: Asking for properties from same ID twice: 0
  
  (waybar:20505): GLib-CRITICAL **: 12:58:10.362: g_variant_get_int32: assertion 'g_variant_is_of_type (value, G_VARIANT_TYPE_INT32)' failed
  
  (waybar:20505): GLib-CRITICAL **: 12:58:10.362: g_variant_get_int32: assertion 'g_variant_is_of_type (value, G_VARIANT_TYPE_INT32)' failed
  
  ...
  ```
  This fixes menus being empty on Waybar.
* Add a task to reregister the StatusNotifierItem if the owner of StatusNotifierWatcher changes